### PR TITLE
Add a MONGOALCHEMY_OPTIONS config variable

### DIFF
--- a/flaskext/mongoalchemy.py
+++ b/flaskext/mongoalchemy.py
@@ -29,6 +29,7 @@ def _get_mongo_uri(app):
     app.config.setdefault('MONGOALCHEMY_PORT', '27017')
     app.config.setdefault('MONGOALCHEMY_USER', None)
     app.config.setdefault('MONGOALCHEMY_PASSWORD', None)
+    app.config.setdefault('MONGOALCHEMY_OPTIONS', None)
 
     auth = ''
 
@@ -38,8 +39,14 @@ def _get_mongo_uri(app):
             auth = '%s:%s' % (auth, app.config.get('MONGOALCHEMY_PASSWORD'))
         auth += '@'
 
-    uri = 'mongodb://%s%s:%s' %(auth, app.config.get('MONGOALCHEMY_SERVER'),
-                                app.config.get('MONGOALCHEMY_PORT'))
+    options = ''
+
+    if app.config.get('MONGOALCHEMY_OPTIONS') is not None:
+        options = "/?%s" % app.config.get('MONGOALCHEMY_OPTIONS')
+
+    uri = 'mongodb://%s%s:%s%s' % (auth, app.config.get('MONGOALCHEMY_SERVER'),
+                                   app.config.get('MONGOALCHEMY_PORT'), options)
+
     return uri
 
 class ImproperlyConfiguredError(Exception):

--- a/tests/test_mongodb_uri.py
+++ b/tests/test_mongodb_uri.py
@@ -29,3 +29,9 @@ class MongoDBURITestCase(BaseTestCase):
         self.app.config['MONGOALCHEMY_PORT'] = '42'
         from flaskext.mongoalchemy import _get_mongo_uri
         assert_equals(_get_mongo_uri(self.app), 'mongodb://database.lukehome.com:42')
+
+    def should_be_able_to_generate_an_uri_with_options(self):
+        self.app.config['MONGOALCHEMY_SERVER'] = 'database.lukehome.com'
+        self.app.config['MONGOALCHEMY_OPTIONS'] = 'safe=true'
+        from flaskext.mongoalchemy import _get_mongo_uri
+        assert_equals(_get_mongo_uri(self.app), 'mongodb://database.lukehome.com:27017/?safe=true')


### PR DESCRIPTION
As documented in

http://www.mongodb.org/display/DOCS/Connections

mongodb allows to pass options in the database uri, but this is not supported by flask-mongoalchemy.
