### PR TITLE
init_app() and save() respect safe argument (insert waits for a response)

### DIFF
--- a/flaskext/mongoalchemy.py
+++ b/flaskext/mongoalchemy.py
@@ -103,7 +103,10 @@ class MongoAlchemy(object):
             raise ImproperlyConfiguredError("You should provide a database name (the MONGOALCHEMY_DATABASE setting).")
 
         uri = _get_mongo_uri(app)
-        self.session = session.Session.connect(app.config.get('MONGOALCHEMY_DATABASE'), host=uri)
+        self.session = session.Session.connect(app.config.get('MONGOALCHEMY_DATABASE'),
+                                               safe=app.config.get('MONGOALCHEMY_SAFE_SESSION', False),
+                                               host=uri,
+                                               )
         self.Document._session = self.session
 
 class Pagination(object):
@@ -242,9 +245,9 @@ class Document(document.Document):
     #: for instances of this document.
     query = None
 
-    def save(self):
+    def save(self, safe=None):
         """Saves the document itself in the database."""
-        self._session.insert(self)
+        self._session.insert(self, safe=safe)
         self._session.flush()
 
     def remove(self):


### PR DESCRIPTION
Changed `MongoAlchemy.init_app` so it takes `app.config.get('MONGOALCHEMY_SAFE_SESSION', False)` into account.
This allows users to create a safe session.
Also changed `Document.save()` to accept safe keyword. If `safe==None` (default), it will be set to `Session.safe` in mongoalchemy.

This is necessary if you have unique or sparse indexes.
