### PR TITLE
Allowing MongoAlchemy to connect to a Replica Set instance.

### DIFF
--- a/flaskext/mongoalchemy/__init__.py
+++ b/flaskext/mongoalchemy/__init__.py
@@ -27,6 +27,7 @@ def _get_mongo_uri(app):
     app.config.setdefault('MONGOALCHEMY_USER', None)
     app.config.setdefault('MONGOALCHEMY_PASSWORD', None)
     app.config.setdefault('MONGOALCHEMY_OPTIONS', None)
+    app.config.setdefault('MONGOALCHEMY_REPLICA_SET', '')
 
     auth = ''
     database = ''
@@ -109,6 +110,7 @@ class MongoAlchemy(object):
         self.session = session.Session.connect(app.config.get('MONGOALCHEMY_DATABASE'),
                                                safe=app.config.get('MONGOALCHEMY_SAFE_SESSION', False),
                                                host=uri,
+                                               replicaSet=app.config.get('MONGOALCHEMY_REPLICA_SET')
                                                )
         self.Document._session = self.session
 

--- a/tests/test_mongoalchemy_object.py
+++ b/tests/test_mongoalchemy_object.py
@@ -103,6 +103,7 @@ class MongoAlchemyObjectTestCase(BaseTestCase):
         self.assertEqual(app.config['MONGOALCHEMY_PORT'], '27017')
         self.assertEqual(app.config['MONGOALCHEMY_USER'], None)
         self.assertEqual(app.config['MONGOALCHEMY_PASSWORD'], None)
+        self.assertEqual(app.config['MONGOALCHEMY_REPLICA_SET'], '')
 
     def test_should_be_able_to_create_two_decoupled_mongoalchemy_instances(self):
         app = Flask(__name__)


### PR DESCRIPTION
Uses the default pymongo connect method and keyword replicaSet.  To use the replica set, its name must be passed into the config item, "MONGOALCHEMY_REPLICA_SET".
